### PR TITLE
Chore reorganise student form

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -46,3 +46,18 @@ nav {
   -ms-filter:'alpha(opacity=0)';
   cursor: pointer;
 }
+html {
+  position: relative;
+  min-height: 100%;
+}
+body {
+  margin-bottom: 60px;
+}
+.footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 60px;
+  line-height: 60px;
+  background-color: #f5f5f5;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
   end
 
   def datepicker_input f, field
-      f.text_field field, class: 'form-control form-control-sm', placeholder: 'DD-MM-YYYY', :data => {:provide => 'datepicker', 'date-format' => 'dd/mm/yyyy',
+      f.text_field field, class: 'form-control form-control-sm', placeholder: 'YYYY-MM-DD', :data => {:provide => 'datepicker', 'date-format' => 'yyyy-mm-dd',
                                                                                                   'date-autoclose' => 'true', 'date-orientation' => 'bottom auto'}
   end
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -2,6 +2,7 @@ class Student < ApplicationRecord
   include PgSearch
   pg_search_scope :search_by_full_name, :against => [:given_name, :surname]
   has_paper_trail on: [:update], only: [:status]
+  after_initialize :default_status
 
   enum status: {
     new_admission: 'New Admission',
@@ -53,6 +54,10 @@ class Student < ApplicationRecord
 
 
   scope :sorted, -> { order(surname: :asc) }
+
+  def default_status
+    self.status ||= 'new_admission'
+  end
 
   def full_name
     "#{surname}, #{given_name}"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -75,6 +75,11 @@
       <%= render partial: 'shared/flash' unless flash.empty? %>
       <%= yield %>
     </div>
+
+    <div class="footer text-center text-muted">
+        Mountbatten Vocational School - School Management System
+    </div>
+
     <%= javascript_include_tag 'application' %>
     <%= cloudinary_js_config %>
 

--- a/app/views/students/edit.html.erb
+++ b/app/views/students/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h3 class="text-center">Edit Student</h3>
+  <h3 class="text-center mt-5 mb-4">Edit Student</h3>
   <%= form_for(@student, url: student_path(@student)) do |f| %>
     <%= render :partial => 'students/shared/student_form', :locals => {:f => f} %>
   <% end %>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -1,4 +1,4 @@
-<h3 class="text-center m-4">Manage Students</h3>
+<h3 class="text-center mt-5 mb-4">Manage Students</h3>
 
 <div class="container mb-3">
   <div class="form-row justify-content-center">

--- a/app/views/students/new.html.erb
+++ b/app/views/students/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h3 class="text-center">Add New Student</h3>
+  <h3 class="text-center mt-5 mb-4">Add New Student</h3>
   <%= form_for(@student, url: students_path) do |f| %>
     <%= render :partial => 'students/shared/student_form', :locals => {:f => f} %>
   <% end %>

--- a/app/views/students/shared/_admission_details.html.erb
+++ b/app/views/students/shared/_admission_details.html.erb
@@ -1,35 +1,33 @@
-<div id="student-admission">
-  <div class="row">
-    <div class="form-group col-md-4">
-      <%= f.label :admission_year, 'Admission Year', class: 'col-form-label required-field' %>
-      <%= f.text_field :admission_year, class: 'form-control form-control-sm' %>
-    </div>
+<div class="card bg-light" id="admission-details">
+  <h4 class="card-header">Admission Details</h4>
+  <div class="card-body">
+    <div class="row">
+      <div class="form-group col-md-4">
+        <%= f.label :admission_year, 'Admission Year', class: 'col-form-label required-field' %>
+        <%= f.text_field :admission_year, class: 'form-control form-control-sm' %>
+      </div>
 
-    <div class="form-group col-md-4">
-      <%= f.label :admission_no, 'Admission No.', class: 'col-form-label' %>
-      <%= f.text_field :admission_no, class: 'form-control form-control-sm' %>
-    </div>
+      <div class="form-group col-md-4">
+        <%= f.label :admission_no, 'Admission No.', class: 'col-form-label' %>
+        <%= f.text_field :admission_no, class: 'form-control form-control-sm' %>
+      </div>
 
-    <div class="form-group col-md-4">
-      <%= f.label :registered_at, 'Date of Registration', class: 'col-form-label required-field' %>
-      <%= f.text_field :registered_at, value: Date.today, :data =>
-                      {:provide => 'datepicker', 'date-format' => 'dd/mm/yyyy', 'date-autoclose' => 'true', 'date-orientation' => 'bottom auto'},
-                      class: 'form-control form-control-sm' %>
-    </div>
+      <div class="form-group col-md-4">
+        <%= f.label :registered_at, 'Date of Registration', class: 'col-form-label required-field' %>
+        <%= f.text_field :registered_at, value: Date.today, :data =>
+                        {:provide => 'datepicker', 'date-format' => 'yyyy-mm-dd', 'date-autoclose' => 'true', 'date-orientation' => 'bottom auto'},
+                        class: 'form-control form-control-sm' %>
+      </div>
 
-    <div class="form-group col-md-4">
-      <%= f.label :status, class: 'col-form-label required-field' %>
-      <%= f.select :status, Student.statuses.keys, {prompt: 'Select Status'}, class: 'form-control form-control-sm' %>
-    </div>
+      <div class="form-group col-md-4">
+        <%= f.label :referred_by, 'Referred By', class: 'col-form-label required-field' %>
+        <%= f.select :referred_by, Student.institutions.keys, {prompt: 'Select Institution'}, class: 'form-control form-control-sm' %>
+      </div>
 
-    <div class="form-group col-md-4">
-      <%= f.label :referred_by, 'Referred By', class: 'col-form-label required-field' %>
-      <%= f.select :referred_by, Student.institutions.keys, {prompt: 'Select Institution'}, class: 'form-control form-control-sm' %>
-    </div>
-
-    <div class="form-group col-md-4">
-      <%= f.label :referral_notes, 'Name of Referee', class: 'col-form-label' %>
-      <%= f.text_field :referral_notes, class: 'form-control form-control-sm' %>
+      <div class="form-group col-md-4">
+        <%= f.label :referral_notes, 'Name of Referee', class: 'col-form-label' %>
+        <%= f.text_field :referral_notes, class: 'form-control form-control-sm' %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/students/shared/_financial_assistance_record_form.html.erb
+++ b/app/views/students/shared/_financial_assistance_record_form.html.erb
@@ -2,7 +2,7 @@
   <td data-for="assistance_type"><%= f.text_field :assistance_type, class: 'form-control form-control-sm' %></td>
   <td data-for="year_obtained"><%= f.text_field :year_obtained, class: 'form-control form-control-sm' %></td>
   <td data-for="duration"><%= f.text_field :duration, class: 'form-control form-control-sm' %></td>
-  <td><%= link_to_remove_association "Delete Record", f, class: 'delete_financial_assistance_record btn btn-danger btn-sm',
+  <td><%= link_to_remove_association "Delete Record", f, class: 'delete_financial_assistance_record btn btn-danger btn-sm float-right',
   data: {confirm:
 'Should you proceed to delete, you will lose this Financial Assistance Record of the student. This action is not reversible.
 Please confirm that you would like to delete by clicking OK.'}%></td>

--- a/app/views/students/shared/_internship_record_fields.html.erb
+++ b/app/views/students/shared/_internship_record_fields.html.erb
@@ -1,41 +1,40 @@
 <div class="nested-fields">
-  <div class="card border-secondary mb-3">
-    <div class="card-body">
-      <div class="form-row">
-        <div class="form-group col-md-6">
-          <%= f.label :internship_company_id, 'Internship company', class: 'col-form-label' %>
-          <%= f.collection_select :internship_company_id, InternshipCompany.all, :id, :name,
-                                                                    {prompt: "Select a company..."}, class: 'form-control form-control-sm'%>
-        </div>
+  <div class="form-row">
+    <div class="form-group col-12">
+      <%= f.label :internship_company_id, 'Internship Company', class: 'col-form-label' %>
+      <%= f.collection_select :internship_company_id, InternshipCompany.all, :id, :name,
+                                                                {prompt: "Select a company..."}, class: 'form-control form-control-sm'%>
+    </div>
 
-        <div class="form-group col-md-6">
-          <%= f.label :internship_supervisor_id, 'Internship supervisor', class: 'col-form-label' %>
-          <%= f.collection_select :internship_supervisor_id, InternshipSupervisor.all, :id, :name,
-                                                                       {prompt: "Select a supervisor..."}, class: 'form-control form-control-sm'%>
-        </div>
+    <div class="form-group col-12">
+      <%= f.label :internship_supervisor_id, 'Internship Supervisor', class: 'col-form-label' %>
+      <%= f.collection_select :internship_supervisor_id, InternshipSupervisor.all, :id, :name,
+                                                                   {prompt: "Select a supervisor..."}, class: 'form-control form-control-sm'%>
+    </div>
 
-        <div class="form-group col-md-6">
-          <%= f.label :from_date, class: 'col-form-label' %>
-          <%= datepicker_input f, :from_date %>
-        </div>
+    <div class="form-group col-6">
+      <%= f.label :from_date, 'From Date', class: 'col-form-label' %>
+      <%= datepicker_input f, :from_date %>
+    </div>
 
-        <div class="form-group col-md-6">
-          <%= f.label :to_date, class: 'col-form-label' %>
-          <%= datepicker_input f, :to_date %>
-        </div>
+    <div class="form-group col-6">
+      <%= f.label :to_date, 'To Date', class: 'col-form-label' %>
+      <%= datepicker_input f, :to_date %>
+    </div>
 
-        <div class="form-group col-md-12">
-          <%= f.label :comments, 'Add comments', class: 'col-form-label' %>
-          <%= f.text_area :comments, class: 'form-control form-control-sm', rows: 3 %>
-        </div>
-
-        <div class="form-group col-md-12">
-          <%= link_to_remove_association "Delete Internship", f, class: 'delete_internship_record btn btn-danger btn-sm float-right',
-          data: {confirm:
-'Should you proceed to delete, you will lose this Internship Record of the student. This action is not reversible.
-Please confirm that you would like to delete by clicking OK.'} %>
-        </div>
-      </div>
+    <div class="form-group col-12">
+      <%= f.label :comments, 'Add Comments', class: 'col-form-label' %>
+      <%= f.text_area :comments, class: 'form-control form-control-sm', rows: 7 %>
     </div>
   </div>
+
+  <div class="row">
+    <div class="col-12">
+      <%= link_to_remove_association "Delete Internship", f, class: 'delete_internship_record btn btn-danger btn-sm float-right',
+      data: {confirm:
+  'Should you proceed to delete, you will lose this Internship Record of the student. This action is not reversible.
+  Please confirm that you would like to delete by clicking OK.'} %>
+    </div>
+  </div>
+  <br><hr>
 </div>

--- a/app/views/students/shared/_medical_history.html.erb
+++ b/app/views/students/shared/_medical_history.html.erb
@@ -1,32 +1,32 @@
-<div id="student-medical-history">
-  <div class="row">
-    <div class="form-group form-group col-md-6">
-      <%= f.label :disability_ids, 'Disabilities', class: 'col-form-label' %>
-      <br>
-      <%= f.collection_select :disability_ids,
-                              @disabilities ,:id,:title, { selected: @student.disability_ids },
-                              { class: 'chosen-select', :multiple=>true, :data => { :placeholder => 'Select Disabilities' }}
-      %>
-    </div>
+<div class="card bg-light" id="student-medical-history">
+  <h4 class="card-header">Medical History</h4>
+  <div class="card-body">
+    <div class="form-group row">
+      <div class="form-group form-group col-6">
+        <%= f.label :disability_ids, 'Disabilities', class: 'col-form-label' %>
+        <br>
+        <%= f.collection_select :disability_ids,
+                                @disabilities ,:id,:title, { selected: @student.disability_ids },
+                                { class: 'chosen-select', :multiple=>true, :data => { :placeholder => 'Select Disabilities' }} %>
+      </div>
 
-    <div class="form-group col-md-6">
-      <%= f.label :medical_condition_ids , 'Medical Conditions', class: 'col-form-label'  %>
-      <br>
-      <%= f.collection_select :medical_condition_ids,
-                              @medical_conditions ,:id,:title, { selected: @student.medical_condition_ids },
-                              { class: 'chosen-select', :multiple=>true, :data => { :placeholder => 'Select Medical conditions' }}
-      %>
-    </div>
-  </div>
-  <div class="form-group row">
-    <div class="form-group col-md-6">
-      <%= f.label :medication_needed, 'Medication Needed', class: 'col-form-label'  %>
-      <%= f.text_area :medication_needed, class: 'form-control form-control-sm', rows: 3 %>
-    </div>
+      <div class="form-group col-6">
+        <%= f.label :medical_condition_ids , 'Medical Conditions', class: 'col-form-label'  %>
+        <br>
+        <%= f.collection_select :medical_condition_ids,
+                                @medical_conditions ,:id,:title, { selected: @student.medical_condition_ids },
+                                { class: 'chosen-select', :multiple=>true, :data => { :placeholder => 'Select Medical conditions' }} %>
+      </div>
 
-    <div class="form-group col-md-6">
-      <%= f.label :allergies, class: 'col-form-label'  %>
-      <%= f.text_area :allergies, class: 'form-control form-control-sm', rows: 3 %>
+      <div class="form-group col-6">
+        <%= f.label :medication_needed, 'Medication Needed', class: 'col-form-label'  %>
+        <%= f.text_area :medication_needed, class: 'form-control form-control-sm', rows: 3 %>
+      </div>
+
+      <div class="form-group col-6">
+        <%= f.label :allergies, class: 'col-form-label'  %>
+        <%= f.text_area :allergies, class: 'form-control form-control-sm', rows: 3 %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/students/shared/_past_education_record_fields.html.erb
+++ b/app/views/students/shared/_past_education_record_fields.html.erb
@@ -1,5 +1,5 @@
 <tr class="nested-fields">
-  <td data-for="school_name"><%= f.text_field :school_name, autofocus: true, class: 'form-control form-control-sm' %></td>
+  <td data-for="school_name"><%= f.text_field :school_name, class: 'form-control form-control-sm' %></td>
   <td data-for="from_date"><%= datepicker_input f, :from_date %></td>
   <td data-for="to_date"><%= datepicker_input f, :to_date %></td>
   <td data-for="qualification"><%= f.text_field :qualification, class: 'form-control form-control-sm' %></td>

--- a/app/views/students/shared/_point_of_contact_fields.html.erb
+++ b/app/views/students/shared/_point_of_contact_fields.html.erb
@@ -1,8 +1,9 @@
 <div class="nested-fields col-md-6">
-  <div class="card border-secondary mb-3">
+  <div class="card bg-light">
+    <h4 class="card-header">Parent/Guardian</h4>
     <div class="card-body">
       <div class="form-row">
-        
+
         <div class="form-group col-md-12">
           <%= f.label :relationship, class: 'col-form-label required-field' %>
           <%= f.text_field :relationship, class: 'form-control form-control-sm' %>
@@ -32,7 +33,7 @@
           <%= f.label :office_number, 'Office Number', class: 'col-form-label' %>
           <%= f.text_field :office_number, class: 'form-control form-control-sm' %>
         </div>
-      
+
         <div class="form-group col-md-12">
           <%= f.label :address, class: 'col-form-label' %>
           <%= f.text_area :address, rows: 3, class: 'form-control form-control-sm' %>
@@ -100,5 +101,5 @@ Please confirm that you would like to delete by clicking OK.'} %>
         </div>
       </div>
     </div>
-  </div>
+  </div><br>
 </div>

--- a/app/views/students/shared/_remark_form.html.erb
+++ b/app/views/students/shared/_remark_form.html.erb
@@ -1,39 +1,36 @@
 <div class="nested-fields">
-  <div class="card border-secondary mb-3">
-    <div class="card-body">
-      <div class="form-row">
-        <%= f.hidden_field :user_id %>
-        <div class="form-group col-md-4">
-          <%= f.label :event_date, 'Event Date', class: 'col-form-label' %>
-          <%= f.text_field :event_date, value: Date.today, :data =>
-              {:provide => 'datepicker', 'date-format' => 'dd/mm/yyyy', 'date-autoclose' => 'true', 'date-orientation' => 'bottom auto'},
-                           class: 'form-control form-control-sm' %>
-        </div>
+  <div class="form-row">
+    <%= f.hidden_field :user_id %>
+    <div class="form-group col-6">
+      <%= f.label :event_date, 'Event Date' %>
+      <%= f.text_field :event_date, value: Date.today, :data =>
+          {:provide => 'datepicker', 'date-format' => 'dd/mm/yyyy', 'date-autoclose' => 'true', 'date-orientation' => 'bottom auto'},
+                       class: 'form-control form-control-sm' %>
+    </div>
 
-        <div class="form-group col-md-4">
-          <%= f.label :category, 'Category', class: 'col-form-label' %>
-          <%= f.select :category, Remark.categories.invert, {include_blank: true, required: true}, class: 'form-control form-control-sm' %>
-        </div>
+    <div class="form-group col-6">
+      <%= f.label :category, 'Category' %>
+      <%= f.select :category, Remark.categories.invert, {include_blank: true, required: true}, class: 'form-control form-control-sm' %>
+    </div>
 
-        <div class="form-group col-md-4">
-          <%= f.label :user_id, 'Posted by', class: 'col-form-label' %><br>
-          <%= f.text_field :user_id, value: f.object.try(:user).try(:name), class: 'form-control-plaintext form-control-sm', readonly: true %>
-        </div>
+    <div class="form-group col-12">
+      <%= f.label :user_id, 'Posted by' %><br>
+      <%= f.text_field :user_id, value: f.object.try(:user).try(:name), class: 'form-control-plaintext form-control-sm', readonly: true %>
+    </div>
 
-        <div class="form-group col-md-12">
-          <%= f.label :details, class: 'col-form-label' %>
-          <%= f.text_area :details, autofocus: true, class: 'form-control', rows: 3 %>
-        </div>
-      </div>
-
-      <div class="row">
-        <div class="col-md-12">
-          <%= link_to_remove_association "Delete Remark", f, class: 'delete_remark btn btn-danger btn-sm float-right',
-          data: {confirm:
-'Should you proceed to delete, you will lose this Student Remark. This action is not reversible.
-Please confirm that you would like to delete by clicking OK.'} %>
-        </div>
-      </div>
+    <div class="form-group col-12">
+      <%= f.label :details %>
+      <%= f.text_area :details, class: 'form-control form-control-sm', rows: 7 %>
     </div>
   </div>
+
+  <div class="row">
+    <div class="col-12">
+      <%= link_to_remove_association "Delete Remark", f, class: 'delete_remark btn btn-danger btn-sm float-right',
+      data: {confirm:
+'Should you proceed to delete, you will lose this Student Remark. This action is not reversible.
+Please confirm that you would like to delete by clicking OK.'} %>
+    </div>
+  </div>
+  <br><hr>
 </div>

--- a/app/views/students/shared/_student_form.html.erb
+++ b/app/views/students/shared/_student_form.html.erb
@@ -1,21 +1,22 @@
 <div class="row">
   <ul class="nav nav-tabs nav-justified mb-3 w-100" id="student-form-tab" role="tablist">
     <li class="nav-item">
-      <a class="nav-link active" id="admission-tab" data-toggle="tab" href="#admission" role="tab" aria-controls="admission" aria-expanded="true">Particulars & Admission Details</a>
+      <a class="nav-link active" id="admission-tab" data-toggle="tab" href="#admission" role="tab" aria-controls="admission" aria-expanded="true">Personal Particulars</a>
     </li>
 
     <li class="nav-item">
-      <a class="nav-link" id="past-educations-tab" data-toggle="tab" href="#past-educations" role="tab" aria-controls="past-educations" aria-expanded="true">Past Education Records</a>
+      <a class="nav-link" id="admin-tab" data-toggle="tab" href="#admin" role="tab" aria-controls="admin" aria-expanded="true">Administrative Details</a>
     </li>
 
     <li class="nav-item">
       <a class="nav-link" id="contacts-tab" data-toggle="tab" href="#contacts" role="tab" aria-controls="contacts" aria-expanded="true">Parent/Guardian Particulars</a>
     </li>
 
-    <li class="nav-item">
-      <a class="nav-link" id="student-particulars-tab" data-toggle="tab" href="#internship-records" role="tab" aria-controls="internship-records" aria-expanded="true">Internship Records</a>
-    </li>
-
+    <% if @student.persisted? %>
+      <li class="nav-item">
+        <a class="nav-link" id="current-info-tab" data-toggle="tab" href="#current-info" role="tab" aria-controls="current-info" aria-expanded="true">Current Info</a>
+      </li>
+    <% end %>
   </ul>
 </div>
 
@@ -23,84 +24,73 @@
   <div class="tab-content w-100" id="tabContent">
     <div class="tab-pane fade show active" id="admission" role="tabpanel" aria-labelledby="admission-tab">
       <br>
-      <h4 class="card-title">Student Particulars</h4>
-      <%= render '/students/shared/student_particulars', f: f %>
-      <hr>
+        <%= render '/students/shared/student_particulars', f: f %>
+      <br>
+        <%= render '/students/shared/medical_history', f: f %>
+      <br>
+    </div>
 
-      <h4 class="card-title">Medical History</h4>
-      <%= render '/students/shared/medical_history', f: f %>
-      <hr>
-
-      <h4 class="card-title">Admission Details</h4>
+    <div class="tab-pane fade" id="admin" role="tabpanel" aria-labelledby="admin-tab">
+      <br>
       <%= render '/students/shared/admission_details', f: f %>
-      <hr>
-
-      <h4 class="card-title">Financial Assistance</h4>
-      <div id="student-financial-assistance">
-      <div class="form-group row">
-        <table class="table">
-          <thead>
-          <tr>
-            <th><%= f.label :assistance_type, 'Assistance Type' %></th>
-            <th><%= f.label :year_obtained, 'Year Obtained' %></th>
-            <th><%= f.label :duration, 'Duration' %></th>
-            <th></th>
-          </tr>
-          </thead>
-          <tbody class="financial_assistance_records">
-          <%= f.fields_for :financial_assistance_records do |financial_assistance_record| %>
-              <%= render '/students/shared/financial_assistance_record_form', f: financial_assistance_record %>
-          <% end %>
-          </tbody>
-        </table>
-      </div>
-    </div>
-
-      <%= link_to_add_association 'Add Financial Assistance Details', f, :financial_assistance_records,
-                                  data: {"association-insertion-node" => "tbody.financial_assistance_records", "association-insertion-method" => "append"},
-                                  partial: '/students/shared/financial_assistance_record_form', class: 'btn btn-primary' %>
-      <hr>
-
-      <h4 class="card-title">Remarks</h4>
-      <div id="student-remarks">
-        <%= f.fields_for :remarks do |remarks| %>
-            <%= render '/students/shared/remark_form', f: remarks %>
-        <% end %>
+      <br>
+      <div class="card bg-light" id="past-educations">
+        <h4 class="card-header">Past Education Records</h4>
+        <div class="card-body">
+          <table class="table">
+            <thead>
+            <tr>
+              <th><%= f.label :school_name, 'School Attended', class: "required-field" %></th>
+              <th><%= f.label :from_date, 'From Date', class: "required-field" %></th>
+              <th><%= f.label :to_date, 'To Date', class: "required-field" %></th>
+              <th><%= f.label :qualification, 'Qualification' %></th>
+              <th><%= f.label :highest_qualification, 'Highest Qualification' %></th>
+              <th></th>
+            </tr>
+            </thead>
+            <tbody class="past_education_record">
+            <%= f.fields_for :past_education_records do |past_education_record| %>
+                <%= render '/students/shared/past_education_record_fields', f: past_education_record %>
+            <% end %>
+            </tbody>
+          </table>
+          <%= link_to_add_association 'Add Past Education Record', f, :past_education_records,
+                                      data: {"association-insertion-node" => "tbody.past_education_record", "association-insertion-method" => "append"},
+                                      partial: '/students/shared/past_education_record_fields', class: 'btn btn-outline-primary' %>
+        </div>
       </div>
 
-      <%= link_to_add_association 'Add Remark', f, :remarks,
-                                  data: {'association-insertion-node' => '#student-remarks', 'association-insertion-method' => 'append'},
-                                  partial: '/students/shared/remark_form', class: 'btn btn-primary' %>
+      <br>
 
-    </div>
+      <div class="card bg-light" id="student-financial-assistance">
+        <h4 class="card-header">Financial Assistance</h4>
+        <div class="card-body">
+          <table class="table">
+            <thead>
+            <tr>
+              <th><%= f.label :assistance_type, 'Assistance Type' %></th>
+              <th><%= f.label :year_obtained, 'Year Obtained' %></th>
+              <th><%= f.label :duration, 'Duration' %></th>
+              <th></th>
+            </tr>
+            </thead>
+            <tbody class="financial_assistance_records">
+            <%= f.fields_for :financial_assistance_records do |financial_assistance_record| %>
+                <%= render '/students/shared/financial_assistance_record_form', f: financial_assistance_record %>
+            <% end %>
+            </tbody>
+          </table>
+          <%= link_to_add_association 'Add Financial Assistance Details', f, :financial_assistance_records,
+                                      data: {"association-insertion-node" => "tbody.financial_assistance_records", "association-insertion-method" => "append"},
+                                      partial: '/students/shared/financial_assistance_record_form', class: 'btn btn-outline-primary' %>
 
-    <div class="tab-pane fade" id="past-educations" role="tabpanel" aria-labelledby="past-educations-tab">
-      <div class="form-group row">
-        <table class="table">
-          <thead>
-          <tr>
-            <th><%= f.label :school_name, 'School Attended', class: "required-field" %></th>
-            <th><%= f.label :from_date, 'From Date', class: "required-field" %></th>
-            <th><%= f.label :to_date, 'To Date', class: "required-field" %></th>
-            <th><%= f.label :qualification, 'Qualification' %></th>
-            <th><%= f.label :highest_qualification, 'Highest Qualification' %></th>
-            <th></th>
-          </tr>
-          </thead>
-          <tbody class="past_education_record">
-          <%= f.fields_for :past_education_records do |past_education_record| %>
-              <%= render '/students/shared/past_education_record_fields', f: past_education_record %>
-          <% end %>
-          </tbody>
-        </table>
+        </div>
       </div>
 
-      <%= link_to_add_association 'Add Past Education Record', f, :past_education_records,
-                                  data: {"association-insertion-node" => "tbody.past_education_record", "association-insertion-method" => "append"},
-                                  partial: '/students/shared/past_education_record_fields', class: 'btn btn-primary' %>
     </div>
 
     <div class="tab-pane fade" id="contacts" role="tabpanel" aria-labelledby="contacts-tab">
+      <br>
       <div class="point_of_contact row">
         <%= f.fields_for :point_of_contacts do |contact| %>
             <%= render '/students/shared/point_of_contact_fields', f: contact %>
@@ -108,27 +98,56 @@
       </div>
       <%= link_to_add_association 'Add Parent / Guardian', f, :point_of_contacts,
                                   data: {"association-insertion-node" => ".point_of_contact", "association-insertion-method" => "append"},
-                                  partial: '/students/shared/point_of_contact_fields', class: 'btn btn-primary' %>
+                                  partial: '/students/shared/point_of_contact_fields', class: 'btn btn-outline-primary' %>
+    <hr>
     </div>
 
-    <div class="tab-pane fade" id="internship-records" role="tabpanel" aria-labelledby="internship-records-tab">
-      <div class="internship_record">
-        <%= f.fields_for :internship_records do |internship_record| %>
-            <%= render '/students/shared/internship_record_fields', f: internship_record %>
-        <% end %>
+    <% if @student.persisted? %>
+      <div class="tab-pane fade" id="current-info" role="tabpanel" aria-labelledby="current-info-tab">
+
+        <div class="form-group row justify-content-center">
+          <div class="col-4 my-4">
+            <%= f.label :status, 'Current Status', class: 'h5 required-field' %>
+            <%= f.select :status, Student.statuses.keys, {prompt: 'Select Status'}, class: 'form-control' %>
+          </div>
+        </div>
+
+        <div class="card-deck">
+
+          <div class="card bg-light">
+            <h4 class="card-header">Internship Records</h4>
+            <div class="card-body">
+              <div id="internship-records">
+                  <%= f.fields_for :internship_records do |internship_record| %>
+                    <%= render '/students/shared/internship_record_fields', f: internship_record %>
+                  <% end %>
+              </div>
+              <%= link_to_add_association 'Add Internship Record', f, :internship_records,
+                                          data: {"association-insertion-node" => "#internship-records", "association-insertion-method" => "append"},
+                                          partial: '/students/shared/internship_record_fields', class: 'btn btn-outline-primary' %>
+            </div>
+          </div>
+
+          <div class="card bg-light">
+            <h4 class="card-header">Remarks</h4>
+            <div class="card-body">
+              <div id="student-remarks">
+                <%= f.fields_for :remarks do |remarks| %>
+                  <%= render '/students/shared/remark_form', f: remarks %>
+                <% end %>
+              </div>
+              <%= link_to_add_association 'Add Remark', f, :remarks,
+                                          data: {'association-insertion-node' => '#student-remarks', 'association-insertion-method' => 'append'},
+                                          partial: '/students/shared/remark_form', class: 'btn btn-outline-primary' %>
+            </div>
+          </div>
+
+        </div>
       </div>
-      <%= link_to_add_association 'Add Internship Record', f, :internship_records,
-                                  data: {"association-insertion-node" => ".internship_record", "association-insertion-method" => "append"},
-                                  partial: '/students/shared/internship_record_fields', class: 'btn btn-primary' %>
-    </div>
-
+    <% end %>
   </div>
 </div>
-
-<hr>
-
+<br>
 <div class="row">
-  <div class="form-group">
-    <%= f.submit :class => 'btn btn-primary btn-lg' %>
-  </div>
+    <div class="form-group"><%= f.submit :class => 'btn btn-primary btn-lg' %></div>
 </div>

--- a/app/views/students/shared/_student_particulars.html.erb
+++ b/app/views/students/shared/_student_particulars.html.erb
@@ -1,69 +1,72 @@
-<div id="student-particulars">
-  <div class="form-group row">
-    <div class="student-profile mx-4">
-      <div class="preview">
-        <%= cl_image_tag(@student.image_id, :crop => 'fill', :width => 150, :height => 150) %>
-        <div class="progress">
-          <div class="progress-bar progress-bar-striped progress-bar-animated bg-success"></div>
+<div class="card bg-light" id="student-particulars">
+  <h4 class="card-header">Personal Particulars</h4>
+  <div class="card-body">
+    <div class="form-group row">
+      <div class="student-profile mx-4">
+        <div class="preview">
+          <%= cl_image_tag(@student.image_id, :crop => 'fill', :width => 150, :height => 150) %>
+          <div class="progress">
+            <div class="progress-bar progress-bar-striped progress-bar-animated bg-success"></div>
+          </div>
+        </div>
+
+        <span class="btn btn-success student-upload-button w-100">
+          <span><i class="fa fa-plus"></i> Upload Photo</span>
+          <%= cl_image_upload_tag :image_id %>
+        </span>
+      </div>
+
+      <div class="col row">
+        <div class="form-group col-md-4">
+          <%= f.label :given_name, 'Given Name', class: "required-field" %>
+          <%= f.text_field :given_name, class: 'form-control form-control-sm' %>
+        </div>
+
+        <div class="form-group col-md-4">
+          <%= f.label :surname, class: "col-form-label required-field" %>
+          <%= f.text_field :surname, class: 'form-control form-control-sm' %>
+        </div>
+
+        <div class="form-group col-md-4">
+          <%= f.label :date_of_birth, 'Date of Birth', class: "col-form-label required-field" %>
+          <%= datepicker_input f, :date_of_birth %>
+        </div>
+
+        <div class="form-group col-md-4">
+          <%= f.label :place_of_birth, 'Place of Birth', class: "col-form-label required-field" %>
+          <%= f.text_field :place_of_birth, class: 'form-control form-control-sm' %>
+        </div>
+
+        <div class="form-group col-md-4">
+          <%= f.label :race, class: "col-form-label required-field" %>
+          <%= f.text_field :race, class: 'form-control form-control-sm' %>
+        </div>
+
+        <div class="form-group col-md-4">
+          <%= f.label :nric, 'NRIC', class: "col-form-label required-field" %>
+          <%= f.text_field :nric, class: 'form-control form-control-sm' %>
+        </div>
+
+        <div class="form-group col-md-4">
+          <%= f.label :citizenship, class: "col-form-label required-field" %>
+          <%= f.text_field :citizenship, class: 'form-control form-control-sm' %>
+        </div>
+
+        <div class="form-group col-md-4">
+          <%= f.label :gender, class: "col-form-label required-field" %>
+          <%= f.select :gender, Student.genders.keys, {prompt: 'Select Gender'}, class: 'form-control form-control-sm' %>
+        </div>
+
+        <div class="form-group col-md-4">
+          <%= f.label :sadeaf_client_reg_no, 'SADeaf Client Registration No.', class: 'col-form-label' %>
+          <%= f.text_field :sadeaf_client_reg_no, class: 'form-control form-control-sm' %>
+        </div>
+
+        <div class="form-group col-md-4">
+          <%= f.label :tshirt_size, 'T-shirt Size', class: 'col-form-label' %>
+          <%= f.select :tshirt_size, Student.tshirt_sizes.keys, {prompt: 'Select t-shirt size'}, class: 'form-control form-control-sm' %>
         </div>
       </div>
-
-      <span class="btn btn-success student-upload-button w-100">
-        <span><i class="fa fa-plus"></i> Upload Photo</span>
-        <%= cl_image_upload_tag :image_id %>
-      </span>
-    </div>
-
-    <div class="col row">
-      <div class="form-group col-md-4">
-        <%= f.label :given_name, 'Given Name', class: "required-field" %>
-        <%= f.text_field :given_name, class: 'form-control form-control-sm' %>
-      </div>
-
-    <div class="form-group col-md-4">
-      <%= f.label :surname, class: "col-form-label required-field" %>
-      <%= f.text_field :surname, class: 'form-control form-control-sm' %>
-    </div>
-
-    <div class="form-group col-md-4">
-      <%= f.label :date_of_birth, 'Date of Birth', class: "col-form-label required-field" %>
-      <%= datepicker_input f, :date_of_birth %>
-    </div>
-
-    <div class="form-group col-md-4">
-      <%= f.label :place_of_birth, 'Place of Birth', class: "col-form-label required-field" %>
-      <%= f.text_field :place_of_birth, class: 'form-control form-control-sm' %>
-    </div>
-
-    <div class="form-group col-md-4">
-      <%= f.label :race, class: "col-form-label required-field" %>
-      <%= f.text_field :race, class: 'form-control form-control-sm' %>
-    </div>
-
-    <div class="form-group col-md-4">
-      <%= f.label :nric, 'NRIC', class: "col-form-label required-field" %>
-      <%= f.text_field :nric, class: 'form-control form-control-sm' %>
-    </div>
-
-    <div class="form-group col-md-4">
-      <%= f.label :citizenship, class: "col-form-label required-field" %>
-      <%= f.text_field :citizenship, class: 'form-control form-control-sm' %>
-    </div>
-
-    <div class="form-group col-md-4">
-      <%= f.label :gender, class: "col-form-label required-field" %>
-      <%= f.select :gender, Student.genders.keys, {prompt: 'Select Gender'}, class: 'form-control form-control-sm' %>
-    </div>
-
-    <div class="form-group col-md-4">
-      <%= f.label :sadeaf_client_reg_no, 'SADeaf Client Registration No.', class: 'col-form-label' %>
-      <%= f.text_field :sadeaf_client_reg_no, class: 'form-control form-control-sm' %>
-    </div>
-
-    <div class="form-group col-md-4">
-      <%= f.label :tshirt_size, 'T-shirt Size', class: 'col-form-label' %>
-      <%= f.select :tshirt_size, Student.tshirt_sizes.keys, {prompt: 'Select t-shirt size'}, class: 'form-control form-control-sm' %>
     </div>
   </div>
-</div>
 </div>

--- a/spec/features/manage_financial_assistance_records_spec.rb
+++ b/spec/features/manage_financial_assistance_records_spec.rb
@@ -9,7 +9,7 @@ describe 'financial assistance records', type: :feature do
   before do
     sign_in yammy
     visit edit_student_path(ali)
-    #click_link 'Past Education Records'
+    click_link 'Administrative Details'
   end
 
   it 'edit financial assistance record', js: true do

--- a/spec/features/manage_past_education_records_spec.rb
+++ b/spec/features/manage_past_education_records_spec.rb
@@ -10,7 +10,7 @@ describe 'manage past education records', type: :feature do
   before do
     sign_in yammy
     visit edit_student_path(ali)
-    click_link 'Past Education Records'
+    click_link 'Administrative Details'
   end
 
   it 'edit student past education record', js: true do

--- a/spec/features/manage_photo_upload_spec.rb
+++ b/spec/features/manage_photo_upload_spec.rb
@@ -1,16 +1,11 @@
 require 'rails_helper'
 
 describe 'student photo upload', type: :feature do
-  let!(:teacher_role) { Role.create(name: 'teacher', super_admin: false) }
-  let!(:teacher_user) { User.create(email: 'teacher1@example.com', password: 'password', name: 'Good Teacher', role: teacher_role) }
-  let!(:student) { Student.create(admission_year: 2016, registered_at: Date.parse('09/09/2017'),
-                                  status: 'new_admission', referred_by: 'association_of_persons_with_special_needs', surname: 'Lee',
-                                  given_name: 'Ali', date_of_birth: Date.parse('09/09/1997'), place_of_birth: 'Singapore', race: 'Chinese',
-                                  nric: 'S8888888D', citizenship: 'Singaporean', gender: 'female')
-  }
+  let!(:yammy) { create(:yammy) }
+  let!(:ali) { create(:student) }
 
   before do
-    sign_in teacher_user
+    sign_in yammy
   end
 
   describe 'create student', js: true do
@@ -34,16 +29,12 @@ describe 'student photo upload', type: :feature do
         select('female', from: 'Gender')
       end
 
-      page.execute_script "window.scrollBy(0,200)"
+      click_link 'Administrative Details'
 
       fill_in 'Admission Year', with: '2017'
       fill_in 'Date of Registration', with: '09/09/2017'
-      select('new_admission', from: 'Status')
       select('association_of_persons_with_special_needs', from: 'Referred By')
 
-      page.execute_script "window.scrollTo(0,0)"
-
-      click_link 'Past Education Records'
       within('#past-educations .nested-fields:nth-of-type(1)') do
         find('td[data-for="school_name"] input').set('Northlight')
         find('td[data-for="from_date"] input').set('02/03/2016')

--- a/spec/features/manage_student_admissions_spec.rb
+++ b/spec/features/manage_student_admissions_spec.rb
@@ -1,23 +1,17 @@
 require 'rails_helper'
 
 describe 'new student admissions', type: :feature do
-  let!(:teacher_role) { Role.create(name: 'teacher', super_admin: false) }
-  let!(:teacher_user) { User.create(email: 'teacher1@example.com', password: 'password', name: 'Good Teacher', role: teacher_role) }
-  let!(:student) { Student.create(admission_year: 2016, admission_no: '16006/2016', registered_at: Date.parse('09/09/2017'), current_class: 'Food & Beverage',
-                                  status: 'new_admission', referred_by: 'association_of_persons_with_special_needs', referral_notes: 'Mdm Referee',
-                                  surname: 'Lee', given_name: 'Ali', date_of_birth: Date.parse('09/09/1997'), place_of_birth: 'Singapore', race: 'Chinese',
-                                  nric: 'S8888888D', citizenship: 'Singaporean', gender: 'female', sadeaf_client_reg_no: '12345/234',
-                                  medication_needed: 'Antihistamines', allergies: 'Peanuts')
-  }
+  let!(:yammy) { create(:yammy) }
+  let!(:ali) { create(:student) }
   let!(:autistic_disability) { Disability.create(title: "Autistic")}
   let!(:disability) { Disability.create(title: "Down's Syndrome")}
   let!(:epilepsy_medical_condition) {MedicalCondition.create(title: "Epilepsy")}
   let!(:medical_condition) {MedicalCondition.create(title: "Asthma")}
-  let!(:cohort) {SchoolClass.create(academic_year: 2016, name: 'Class 1.1', year: 1, form_teacher_id: teacher_user.id)}
-  let!(:student_class) {StudentClass.create(student_id: student.id, school_class_id: cohort.id)}
+  let!(:cohort) { create(:school_class, form_teacher_id: yammy.id) }
+  let!(:student_class) {StudentClass.create(student_id: ali.id, school_class_id: cohort.id)}
 
   before do
-    sign_in teacher_user
+    sign_in yammy
   end
 
   describe 'create student', js: true do
@@ -26,19 +20,12 @@ describe 'new student admissions', type: :feature do
       click_link 'Students'
       click_link 'Add New Student'
 
-      fill_in 'Admission Year', with: '2017'
-      fill_in 'Admission No.', with: '16006/2016'
-      fill_in 'Date of Registration', with: '09/09/2017'
-      select('new_admission', from: 'Status')
-      select('association_of_persons_with_special_needs', from: 'Referred By')
-      fill_in 'Name of Referee', with: 'Mdm Referee'
-
       page.execute_script "window.scrollTo(0,0)"
 
       within('#student-particulars') do
         fill_in 'Surname', with: 'Lee'
         fill_in 'Given Name', with: 'Ali'
-        fill_in 'Date of Birth', with: '09/09/1997'
+        fill_in 'Date of Birth', with: '1997-09-09'
         fill_in 'Place of Birth', with: 'Singapore'
         fill_in 'Race', with: 'Chinese'
         fill_in 'NRIC', with: 'S8888888D'
@@ -49,8 +36,6 @@ describe 'new student admissions', type: :feature do
         find('#student_place_of_birth').click
       end
 
-      page.execute_script "window.scrollBy(0,400)"
-
       within('#student-medical-history') do
         fill_in 'Medication Needed', with: 'Antihistamines'
         fill_in 'Allergies', with: 'Peanuts'
@@ -58,26 +43,34 @@ describe 'new student admissions', type: :feature do
         chosen_select('Epilepsy', "Asthma", from: 'Medical Conditions')
       end
 
-      page.execute_script "window.scrollBy(0,1000)"
+      page.execute_script "window.scrollTo(0,0)"
+      click_link 'Administrative Details'
 
-      click_link 'Add Remark'
-      within('#student-remarks') do
-        select('Incident', from: 'Category')
-        fill_in 'Details', with: 'Student pushed another student'
+      within('#admission-details') do
+        fill_in 'Admission Year', with: '2017'
+        fill_in 'Admission No.', with: '16006/2016'
+        fill_in 'Date of Registration', with: '2017-09-09'
+        select('association_of_persons_with_special_needs', from: 'Referred By')
+        fill_in 'Name of Referee', with: 'Mdm Referee'
       end
 
-      page.execute_script "window.scrollTo(0,0)"
-
-      click_link 'Past Education Records'
       within('#past-educations .nested-fields:nth-of-type(1)') do
         find('td[data-for="school_name"] input').set('Northlight')
-        find('td[data-for="from_date"] input').set('02/03/2016')
-        find('td[data-for="to_date"] input').set('02/03/2017')
+        find('td[data-for="from_date"] input').set('2016-03-02')
+        find('td[data-for="to_date"] input').set('2017-03-02')
         find('td[data-for="qualification"] input').set('GCE O Levels')
         find('td[data-for="highest_qualification"] input').set(true)
       end
 
+      within('#student-financial-assistance .nested-fields:nth-of-type(1)') do
+        find('td[data-for="assistance_type"] input').set('Pocket Fund')
+        find('td[data-for="year_obtained"] input').set('2017')
+        find('td[data-for="duration"] input').set('1 year')
+      end
+
+      page.execute_script "window.scrollTo(0,0)"
       click_link 'Parent/Guardian Particulars'
+
       within('#contacts .nested-fields:nth-of-type(1)') do
         fill_in 'Surname', with: 'Ong'
         fill_in 'Given Name', with: 'Pearly'
@@ -88,7 +81,7 @@ describe 'new student admissions', type: :feature do
         fill_in 'Languages Spoken', with: 'English'
         fill_in 'ID Number', with: 'S8888888D'
         select('blue', from: 'ID Type')
-        fill_in 'Date of Birth', with: '01/01/2000'
+        fill_in 'Date of Birth', with: '2000-01-01'
         fill_in 'Place of Birth', with: 'Singapore'
         fill_in 'Nationality', with: 'Singaporean'
         fill_in 'Occupation', with: 'Clerk'
@@ -98,7 +91,6 @@ describe 'new student admissions', type: :feature do
         fill_in 'Relationship', with: 'Mother'
       end
 
-      page.execute_script "window.scrollBy(0,10000)"
       click_button 'Create Student'
 
       expect(page).to have_text 'Successfully created student'
@@ -108,7 +100,7 @@ describe 'new student admissions', type: :feature do
       within("#student-#{new_student.id}") do
         expect(find('td[data-for="given_name"]')).to have_content 'Ali'
         expect(find('td[data-for="surname"]')).to have_content 'Lee'
-        expect(find('td[data-for="date_of_birth"]')).to have_content Date.new(1997,9,9)
+        expect(find('td[data-for="date_of_birth"]')).to have_content '1997-09-09'
         expect(find('td[data-for="gender"]')).to have_content 'female'
         expect(find('td[data-for="status"]')).to have_content 'new_admission'
         expect(find('td[data-for="disabilities"]')).to have_content("Autistic")
@@ -136,6 +128,7 @@ describe 'new student admissions', type: :feature do
       expect(new_student.registered_at).to eq Date.parse('09/09/2017')
       expect(new_student.referred_by).to eq 'association_of_persons_with_special_needs'
       expect(new_student.referral_notes).to eq 'Mdm Referee'
+      expect(new_student.status).to eq 'new_admission'
       expect(new_student.place_of_birth).to eq 'Singapore'
       expect(new_student.race).to eq 'Chinese'
       expect(new_student.nric).to eq 'S8888888D'
@@ -167,50 +160,32 @@ describe 'new student admissions', type: :feature do
       expect(new_student.disability_ids).to include(autistic_disability.id, disability.id)
       expect(new_student.medical_conditions.first.title).to eq 'Epilepsy'
       expect(new_student.medical_condition_ids).to include(medical_condition.id, epilepsy_medical_condition.id)
-
-      expect(new_student.remarks.last.category).to eq 'incident'
-      expect(new_student.remarks.last.details).to eq 'Student pushed another student'
     end
   end
 
   describe 'edit student', js: true do
     before do
-      student.student_disabilities.create(disability: disability)
-      student.student_disabilities.create(disability: autistic_disability)
-      student.student_medical_conditions.create(medical_condition: medical_condition)
-      student.student_medical_conditions.create(medical_condition: epilepsy_medical_condition)
+      ali.student_disabilities.create(disability: disability)
+      ali.student_disabilities.create(disability: autistic_disability)
+      ali.student_medical_conditions.create(medical_condition: medical_condition)
+      ali.student_medical_conditions.create(medical_condition: epilepsy_medical_condition)
     end
 
     it 'edits admission details' do
-      visit students_path
+      visit edit_student_path(ali)
 
-      within("#student-#{student.id}") do
-        find('td[data-for="view"]').find(".fa").click
-      end
-      within("#student-details-#{student.id}") do
-        find_link('Edit').click
-      end
       within('.edit_student') do
+        click_link 'Administrative Details'
         fill_in 'Admission Year', with: 2017
       end
-      page.execute_script "window.scrollBy(0,10000)"
       click_button 'Update Student'
 
       expect(page).to have_text 'Successfully updated student'
-      expect(student.reload.admission_year).to eq 2017
+      expect(ali.reload.admission_year).to eq 2017
     end
 
     it 'edits medical conditions in student details' do
-      visit students_path
-
-      within("#student-#{student.id}") do
-        find('td[data-for="view"]').find(".fa").click
-      end
-      within("#student-details-#{student.id}") do
-        find_link('Edit').click
-      end
-
-      page.execute_script "window.scrollTo(0,400)"
+      visit edit_student_path(ali)
 
       within('#student-medical-history') do
         chosen_unselect('Autistic', from: 'Disabilities')
@@ -221,21 +196,17 @@ describe 'new student admissions', type: :feature do
       click_button 'Update Student'
 
       expect(page).to have_text 'Successfully updated student'
-      expect(student.reload.disabilities.first.title).to eq "Down's Syndrome"
-      expect(student.reload.disability_ids).to include(disability.id, disability.id)
+      expect(ali.reload.disabilities.first.title).to eq "Down's Syndrome"
+      expect(ali.reload.disability_ids).to include(disability.id, disability.id)
 
-      expect(student.reload.medical_conditions.first.title).to eq 'Asthma'
-      expect(student.reload.medical_condition_ids).to include(medical_condition.id, medical_condition.id)
+      expect(ali.reload.medical_conditions.first.title).to eq 'Asthma'
+      expect(ali.reload.medical_condition_ids).to include(medical_condition.id, medical_condition.id)
     end
   end
 
   describe 'view student' do
     it 'displays the details of a student' do
-      visit students_path
-
-      within("#student-#{student.id}") do
-        find('td[data-for="given_name"]').find(".student-given-name").click
-      end
+      visit student_path(ali)
 
       expect(page).to have_link 'Edit'
 
@@ -256,10 +227,10 @@ describe 'new student admissions', type: :feature do
     it 'deletes an existing student' do
       visit students_path
 
-      within("#student-#{student.id}") do
+      within("#student-#{ali.id}") do
         find('td[data-for="view"]').find(".fa").click
       end
-      within("#student-details-#{student.id}") do
+      within("#student-details-#{ali.id}") do
         accept_confirm_dialog {
           find('.delete_student', visible: true).click
         }
@@ -271,17 +242,12 @@ describe 'new student admissions', type: :feature do
   end
 
   describe 'search student', js: true do
-    let!(:student2) { Student.create(admission_year: 2016, admission_no: '16006/2016', registered_at: Date.parse('09/09/2017'), current_class: 'Food & Beverage',
-                                status: 'new_admission', referred_by: 'association_of_persons_with_special_needs', referral_notes: 'Mdm Referee',
-                                surname: 'Lee', given_name: 'Robin', date_of_birth: Date.parse('09/09/1997'), place_of_birth: 'Singapore', race: 'Chinese',
-                                nric: 'S8888888D', citizenship: 'Singaporean', gender: 'female', sadeaf_client_reg_no: '12345/234',
-                                medication_needed: 'Antihistamines', allergies: 'Peanuts')
-    }
+    let!(:robin) { create(:student, given_name: 'Robin') }
 
     it 'searches students by academic year and class' do
       visit students_path
-      select('2016', from: 'academic_year')
-      select('Class 1.1', from: 'class_name')
+      select('2017', from: 'academic_year')
+      select('Year 2 Food & Beverages', from: 'class_name')
       click_on 'Search by Academic Year or Class'
 
       expect(find('td[data-for="given_name"]')).to have_content 'Ali'

--- a/spec/features/manage_student_internships_spec.rb
+++ b/spec/features/manage_student_internships_spec.rb
@@ -19,17 +19,17 @@ describe 'manage internship records', type: :feature do
   before do
     sign_in yammy
     visit edit_student_path(ali)
-    click_link 'Internship Records'
+    click_link 'Current Info'
   end
 
   it 'add a record', js: true do
     click_link 'Add Internship Record'
     within("#internship-records .nested-fields:nth-of-type(2)") do
-      select('Hilton Hotel', from: 'Internship company')
-      select('aaaa', from: 'Internship supervisor')
-      fill_in 'From date', with: '01/02/2017'
-      fill_in 'To date', with: '03/02/2017'
-      fill_in 'Add comments', with: 'Good boy'
+      select('Hilton Hotel', from: 'Internship Company')
+      select('aaaa', from: 'Internship Supervisor')
+      fill_in 'From Date', with: '01/02/2017'
+      fill_in 'To Date', with: '03/02/2017'
+      fill_in 'Add Comments', with: 'Good boy'
     end
 
     page.execute_script "window.scrollBy(0,1000)"
@@ -41,7 +41,7 @@ describe 'manage internship records', type: :feature do
 
   it 'edit a record', js: true do
     within("#internship-records .nested-fields:nth-of-type(1)") do
-      fill_in 'Add comments', with: 'Student slapped another student'
+      fill_in 'Add Comments', with: 'Student slapped another student'
     end
 
     page.execute_script "window.scrollBy(0,1000)"

--- a/spec/features/track_student_status_spec.rb
+++ b/spec/features/track_student_status_spec.rb
@@ -10,10 +10,8 @@ describe 'track student status', type: :feature do
   end
 
   it 'displays history of student status', js: true do
-    page.execute_script "window.scrollBy(0,500)"
-    within('#student-admission') do
-      select('internship', from: 'Status')
-    end
+    click_link 'Current Info'
+    select('internship', from: 'Status')
 
     click_button 'Update Student'
     expect(page).to have_text 'Successfully updated student'


### PR DESCRIPTION
[#151969793]
- Move Status, Internship Records, Remarks into new tab Current Info which can only be viewed in Edit mode.
- Remove Status from New Student form and set default status to New Admission.
- Reorganise student form into cards and move Admission Details, Past Edu, Financial Records into separate tab Administrative Details for neatness (see screenshots below)
- Cleanup (add footer, change datepicker format for consistency)

Screenshots

![image](https://user-images.githubusercontent.com/28617936/32401597-1f0b5ca4-c14d-11e7-810e-961319b4b99a.png)

![image](https://user-images.githubusercontent.com/28617936/32401605-393912ba-c14d-11e7-899f-12ccd60f99b6.png)

![image](https://user-images.githubusercontent.com/28617936/32401611-5a1d7048-c14d-11e7-981f-0e1258ec4ad0.png)

